### PR TITLE
feat: expand country dataset and add Claude Code automation tooling

### DIFF
--- a/.claude/agents/data-validator.md
+++ b/.claude/agents/data-validator.md
@@ -1,0 +1,52 @@
+---
+name: data-validator
+description: Validates country data files in this project. Use when you want to check countries.csv or countries.json for issues like duplicates, missing fields, empty values, or invalid continent names.
+tools:
+  - Read
+  - Bash
+---
+
+You are a data validator for the hello-world project's country dataset.
+
+When invoked, validate the country data by following these steps:
+
+1. Check if `countries.csv` or `countries.json` exists. Prefer CSV. If neither exists, tell the user to run `python3 generate_countries_csv.py` first.
+
+2. Load and inspect the data, checking for:
+   - **Missing fields** — every row must have: Continent, Country, Capital, Currency, Language
+   - **Empty values** — flag any row where a field is blank
+   - **Duplicate countries** — flag any country name that appears more than once
+   - **Invalid continents** — valid values are: Asia, Europe, Africa, North America, South America, Oceania
+   - **Whitespace issues** — leading/trailing spaces in any field
+
+3. Report results in this format:
+
+```
+Data Validation Report — <filename>
+Total rows: X
+
+✅ No issues found.
+```
+
+Or if there are issues:
+
+```
+Data Validation Report — <filename>
+Total rows: X
+
+❌ Issues found:
+
+[Missing fields]
+- Row 5: "Tanzania" is missing Currency
+
+[Duplicates]
+- "Brazil" appears 2 times (rows 3, 47)
+
+[Invalid continents]
+- Row 12: "Middle East" is not a valid continent
+
+[Empty values]
+- Row 8: Language is empty
+```
+
+4. End with a one-line summary: how many issues were found, or confirmation that the data is clean.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); echo \"$f\" | grep -q 'generate_countries_csv.py' && cd /mnt/c/Users/kkumar/repo/hello-world && python3 generate_countries_csv.py 2>/dev/null && echo '{\"systemMessage\": \"countries.csv regenerated automatically.\"}' || true",
+            "statusMessage": "Regenerating country data..."
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '{\"systemMessage\": \"Claude is done.\"}'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/countries.csv
+++ b/countries.csv
@@ -23,6 +23,7 @@ Europe,Poland,Warsaw,PLN,Polish
 Europe,Portugal,Lisbon,EUR,Portuguese
 Europe,Greece,Athens,EUR,Greek
 Europe,Russia,Moscow,RUB,Russian
+Europe,Georgia,Tbilisi,GEL,Georgian
 Africa,Nigeria,Abuja,NGN,English
 Africa,South Africa,Pretoria,ZAR,Zulu/Xhosa/Afrikaans/English
 Africa,Egypt,Cairo,EGP,Arabic
@@ -52,3 +53,5 @@ South America,Bolivia,Sucre,BOB,Spanish/Quechua/Aymara
 South America,Uruguay,Montevideo,UYU,Spanish
 Oceania,Australia,Canberra,AUD,English
 Oceania,New Zealand,Wellington,NZD,English/Māori
+Oceania,Fiji,Suva,FJD,
+Oceania,Papua New Guinea,Port Moresby,PGK,English/Tok Pisin/Hiri Motu

--- a/generate_countries_csv.py
+++ b/generate_countries_csv.py
@@ -34,6 +34,7 @@ COUNTRIES = [
     {"Continent": "Europe", "Country": "Portugal", "Capital": "Lisbon", "Currency": "EUR", "Language": "Portuguese"},
     {"Continent": "Europe", "Country": "Greece", "Capital": "Athens", "Currency": "EUR", "Language": "Greek"},
     {"Continent": "Europe", "Country": "Russia", "Capital": "Moscow", "Currency": "RUB", "Language": "Russian"},
+    {"Continent": "Europe", "Country": "Georgia", "Capital": "Tbilisi", "Currency": "GEL", "Language": "Georgian"},
     # Africa
     {"Continent": "Africa", "Country": "Nigeria", "Capital": "Abuja", "Currency": "NGN", "Language": "English"},
     {"Continent": "Africa", "Country": "South Africa", "Capital": "Pretoria", "Currency": "ZAR", "Language": "Zulu/Xhosa/Afrikaans/English"},
@@ -67,6 +68,8 @@ COUNTRIES = [
     # Oceania
     {"Continent": "Oceania", "Country": "Australia", "Capital": "Canberra", "Currency": "AUD", "Language": "English"},
     {"Continent": "Oceania", "Country": "New Zealand", "Capital": "Wellington", "Currency": "NZD", "Language": "English/Māori"},
+    {"Continent": "Oceania", "Country": "Fiji", "Capital": "Suva", "Currency": "FJD"},
+    {"Continent": "Oceania", "Country": "Papua New Guinea", "Capital": "Port Moresby", "Currency": "PGK", "Language": "English/Tok Pisin/Hiri Motu"},
 ]
 
 FIELDS = ["Continent", "Country", "Capital", "Currency", "Language"]


### PR DESCRIPTION
## What
Expands the country dataset with 3 new entries and adds Claude Code automation tooling for data validation and auto-regeneration.

## Why
The dataset was missing several countries, and manual regeneration of `countries.csv` after editing the source script was error-prone. The new agent and hook automate validation and keep generated files in sync.

## Changes
- **`generate_countries_csv.py`** — Added Georgia (Europe), Fiji (Oceania), and Papua New Guinea (Oceania) to the `COUNTRIES` list
- **`countries.csv`** — Regenerated to reflect the 3 new entries
- **`.claude/agents/data-validator.md`** — New custom Claude Code agent that validates country data files for missing fields, empty values, duplicates, invalid continents, and whitespace issues
- **`.claude/settings.json`** — Added a `PostToolUse` hook that auto-regenerates `countries.csv` whenever `generate_countries_csv.py` is edited; also adds a `Stop` hook that notifies when Claude finishes

## Testing
1. Run `python3 generate_countries_csv.py` and confirm Georgia, Fiji, and Papua New Guinea appear in `countries.csv`
2. Run `python3 filter_countries.py --continent Europe` and confirm Georgia is listed
3. Run `python3 filter_countries.py --continent Oceania` and confirm Fiji and Papua New Guinea are listed
4. In Claude Code, edit `generate_countries_csv.py` and confirm `countries.csv` is regenerated automatically (status message: "Regenerating country data...")
5. Invoke the `data-validator` agent and confirm it reports the Fiji missing-Language issue
