### PR TITLE
feat(epic-newgame-fetch): add Epic free games email notifier

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,0 +1,29 @@
+name: Epic Free Games Notifier
+
+on:
+  schedule:
+    # 00:00 UTC every Friday = 8:00 AM Malaysia time (UTC+8)
+    - cron: '0 0 * * 5'
+  workflow_dispatch: {}   # lets you manually trigger a test run from GitHub's UI
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Run notifier script
+        env:
+          EMAIL_ADDRESS: ${{ secrets.EMAIL_ADDRESS }}
+          EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}
+          TO_EMAIL: ${{ secrets.TO_EMAIL }}
+        run: python epic-newgame-fetch/notify_free_games.py

--- a/epic-newgame-fetch/README.md
+++ b/epic-newgame-fetch/README.md
@@ -1,0 +1,54 @@
+# Epic Free Games Notifier
+
+Emails you the current week's free Epic Games Store game(s) every Friday
+at 8:00 AM Malaysia time — completely free to run, using GitHub Actions.
+
+## How it works
+- A GitHub Actions "cron job" wakes up every Friday at 00:00 UTC (= 8:00 AM MYT)
+- It runs `notify_free_games.py`, which calls Epic's own free-games API
+  (the same one the store website uses) to find what's currently free
+- It emails you the result via Gmail SMTP
+
+## Setup (10 minutes, one-time)
+
+### 1. Create a GitHub repo
+- Go to github.com → New repository (can be private)
+- Upload these files, keeping the folder structure:
+  - `epic-newgame-fetch/notify_free_games.py`
+  - `epic-newgame-fetch/README.md`
+  - `.github/workflows/notify.yml` (must be in this exact path — GitHub Actions requires it)
+
+### 2. Get a Gmail "App Password"
+You can't use your normal Gmail password for this — Google requires an
+App Password for scripts:
+1. Go to https://myaccount.google.com/apppasswords
+2. Sign in, create a new app password (name it "Epic Notifier")
+3. Copy the 16-character password it gives you
+
+(If you don't use Gmail, any SMTP provider works — just change the
+`smtp.gmail.com` line in the script to your provider's SMTP server.)
+
+### 3. Add secrets to your GitHub repo
+In your repo: Settings → Secrets and variables → Actions → New repository secret.
+Add these three:
+
+| Secret name      | Value                                   |
+|-------------------|------------------------------------------|
+| `EMAIL_ADDRESS`   | The Gmail address sending the email      |
+| `EMAIL_PASSWORD`  | The 16-character App Password from step 2 |
+| `TO_EMAIL`        | The email address you want to receive it |
+
+### 4. Test it
+Go to the "Actions" tab in your repo → "Epic Free Games Notifier" →
+"Run workflow" (this is the `workflow_dispatch` trigger) to send yourself
+a test email immediately, without waiting for Friday.
+
+### 5. Done
+It will now run automatically every Friday at 8:00 AM Malaysia time.
+
+## Notes
+- GitHub Actions free tier gives you 2,000 minutes/month — this uses
+  about 10 seconds/week, so it's effectively unlimited for this use case.
+- If Epic changes their API structure in the future, the script may need
+  a small tweak — the API has been stable for years, so this is unlikely
+  to happen often.

--- a/epic-newgame-fetch/notify_free_games.py
+++ b/epic-newgame-fetch/notify_free_games.py
@@ -1,0 +1,88 @@
+"""
+Checks Epic Games Store's free games API and emails the current week's
+free game(s) to a recipient. Designed to run on a schedule (see the
+GitHub Actions workflow in .github/workflows/notify.yml).
+"""
+
+import os
+import smtplib
+import requests
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+
+EPIC_API = (
+    "https://store-site-backend-static.ak.epicgames.com/"
+    "freeGamesPromotions?locale=en-US&country=US&allowCountries=US"
+)
+
+
+def get_current_free_games():
+    resp = requests.get(EPIC_API, timeout=15)
+    resp.raise_for_status()
+    data = resp.json()
+
+    elements = data["data"]["Catalog"]["searchStore"]["elements"]
+    current_free = []
+
+    for game in elements:
+        promotions = game.get("promotions")
+        if not promotions:
+            continue
+        offers = promotions.get("promotionalOffers") or []
+        # A game is CURRENTLY free if promotionalOffers (not upcoming) is non-empty
+        if offers:
+            title = game.get("title", "Unknown title")
+            slug = (
+                game.get("catalogNs", {}).get("mappings", [{}])[0].get("pageSlug")
+                or game.get("productSlug")
+                or game.get("urlSlug")
+            )
+            url = (
+                f"https://store.epicgames.com/en-US/p/{slug}"
+                if slug
+                else "https://store.epicgames.com/en-US/free-games"
+            )
+            current_free.append((title, url))
+
+    return current_free
+
+
+def build_email_body(games):
+    if not games:
+        return (
+            "Couldn't find any currently-free games on Epic's API this run. "
+            "Check https://store.epicgames.com/en-US/free-games manually."
+        )
+    lines = ["This week's free games on Epic Games Store:\n"]
+    for title, url in games:
+        lines.append(f"- {title}\n  {url}")
+    return "\n\n".join(lines)
+
+
+def send_email(subject, body):
+    sender = os.environ["EMAIL_ADDRESS"]
+    password = os.environ["EMAIL_PASSWORD"]
+    recipient = os.environ["TO_EMAIL"]
+
+    msg = MIMEMultipart()
+    msg["From"] = sender
+    msg["To"] = recipient
+    msg["Subject"] = subject
+    msg.attach(MIMEText(body, "plain"))
+
+    with smtplib.SMTP_SSL("smtp.gmail.com", 465) as server:
+        server.login(sender, password)
+        server.sendmail(sender, recipient, msg.as_string())
+
+
+def main():
+    games = get_current_free_games()
+    body = build_email_body(games)
+    subject = "🎮 This Week's Free Games on Epic Games Store"
+    send_email(subject, body)
+    print("Email sent.")
+    print(body)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What
Add an automated GitHub Actions workflow that emails Epic Games Store's free games every Friday at 8 AM Malaysia time.

## Why
Convenient weekly notification so you never miss a free game without having to manually check the Epic store.

## Changes
- `.github/workflows/notify.yml` — GitHub Actions workflow scheduled via cron (`0 0 * * 5`); includes `workflow_dispatch` for manual test runs
- `epic-newgame-fetch/notify_free_games.py` — Python script that calls Epic's free games API and sends an email via Gmail SMTP using three GitHub secrets (`EMAIL_ADDRESS`, `EMAIL_PASSWORD`, `TO_EMAIL`)
- `epic-newgame-fetch/README.md` — setup instructions covering App Password creation, secret configuration, and manual test trigger

## Testing
1. Merge into `master` so the workflow is active
2. Go to **Actions** → **Epic Free Games Notifier** → **Run workflow**
3. Wait ~30 seconds and check the inbox of the `TO_EMAIL` address
4. Expected: email with subject "🎮 This Week's Free Games on Epic Games Store" listing current free games with their store URLs
